### PR TITLE
Fix(ci): Ensure clean state between package tests

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -27,7 +27,7 @@ jobs:
             $package = $packagePath.Name
             $newVersion = 0
             # Test independently every type of update and commit what works
-            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL', 'DYNAMIC_URL', 'MSIXBUNDLE_URL')) {
+            foreach ($UPDATE_TYPE in ('GITHUB_URL', 'MSIXBUNDLE_URL', 'VERSION_URL', 'DEPENDENCIES', 'DYNAMIC_URL')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
               echo "$package $version"
@@ -41,10 +41,14 @@ jobs:
                   $newVersion = $version
                   # Save the update type to use it in the commit
                   $finalUpdateType = $UPDATE_TYPE
+                  # break when a successful install is found
+                  break
                 } else {
                   echo "$package $version FAILED"
                   git diff
                 }
+                # Ensure a clean state for consecutive package install attempts
+                choco uninstall $package -y
               }
               # Clean changes and built packages
               git restore .
@@ -74,4 +78,3 @@ jobs:
           # GH actions can not trigger other GH actions,
           # use a Personal Access Token to trigger the CI workflow in the created PR
           token: ${{ secrets.REPO_TOKEN }}
-


### PR DESCRIPTION
The package update workflow was vulnerable to state pollution, causing false-positive test results. A successful test of one version could leave artifacts on the file system that would cause a subsequent test of a new, broken version to incorrectly pass.

This was observed when a successful installation of nmap v7.93 left  on the system, which then caused the test for the broken v7.94 package to succeed because the file already existed.

This change adds a  command after each test run. This ensures every package test starts in a clean environment, preventing artifacts from one test from influencing another and guaranteeing that installation failures are accurately detected.